### PR TITLE
feat: Add end-to-end tests for dashboard, landing, register, and signin pages

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -4,8 +4,9 @@ const baseURL = process.env.E2E_BASE_URL ?? "http://localhost:3000";
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  timeout: 30000,
-  retries: 0,
+  timeout: 60000,
+  retries: 1,
+  workers: 3,
   webServer: {
     command: process.env.CI ? "npm run start" : "npm run dev",
     url: baseURL,

--- a/frontend/tests/e2e/dashboard.spec.ts
+++ b/frontend/tests/e2e/dashboard.spec.ts
@@ -1,0 +1,236 @@
+import { test, expect } from "@playwright/test";
+
+// Seed sessionStorage with a valid auth token so the protected layout renders.
+const seedAuth = async (page: import("@playwright/test").Page) => {
+  await page.addInitScript(() => {
+    sessionStorage.setItem(
+      "auth_user",
+      JSON.stringify({ accessToken: "test-token", userId: 1, expireInSeconds: 3600 })
+    );
+  });
+};
+
+const mockProjectsEndpoint = (
+  page: import("@playwright/test").Page,
+  items: object[],
+  totalCount = items.length
+) =>
+  page.route("**/api/services/app/Project/GetAll", route =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ result: { items, totalCount } }),
+    })
+  );
+
+const sampleProjects = [
+  {
+    id: 1,
+    workspaceId: 1,
+    name: "My Next App",
+    prompt: "A demo app",
+    promptVersion: 1,
+    framework: 1, // NextJS
+    language: 1, // TypeScript
+    databaseOption: 1,
+    includeAuth: false,
+    status: 5, // Deployed -> "Live"
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-06-01T12:00:00Z",
+  },
+  {
+    id: 2,
+    workspaceId: 1,
+    name: "React Dashboard",
+    prompt: "A dashboard",
+    promptVersion: 1,
+    framework: 2, // ReactVite
+    language: 2, // JavaScript
+    databaseOption: 1,
+    includeAuth: false,
+    status: 1, // Draft
+    createdAt: "2024-02-01T00:00:00Z",
+    updatedAt: "2024-06-02T08:00:00Z",
+  },
+  {
+    id: 3,
+    workspaceId: 1,
+    name: "Angular Portal",
+    prompt: "A portal",
+    promptVersion: 1,
+    framework: 3, // Angular
+    language: 1, // TypeScript
+    databaseOption: 1,
+    includeAuth: true,
+    status: 6, // Failed
+    createdAt: "2024-03-01T00:00:00Z",
+    updatedAt: "2024-06-03T10:00:00Z",
+  },
+];
+
+test.describe("Dashboard page - unauthenticated", () => {
+  test("redirects to /auth when not authenticated", async ({ page }) => {
+    await page.goto("/dashboard");
+    await page.waitForURL(/\/auth/, { timeout: 10000 });
+    await expect(page).toHaveURL(/\/auth/);
+  });
+});
+
+test.describe("Dashboard page", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedAuth(page);
+  });
+
+  test("renders My projects heading", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+    await expect(page.getByRole("heading", { name: "My projects" })).toBeVisible();
+  });
+
+  test("shows loading state while projects are being fetched", async ({ page }) => {
+    // Delay the API response so we can catch the loading state
+    await page.route("**/api/services/app/Project/GetAll", async route => {
+      await new Promise(resolve => setTimeout(resolve, 500));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ result: { items: [], totalCount: 0 } }),
+      });
+    });
+    await page.goto("/dashboard");
+    await expect(page.getByText("Loading projects...")).toBeVisible();
+  });
+
+  test("renders project cards from API response", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+    await expect(page.getByText("My Next App")).toBeVisible();
+    await expect(page.getByText("React Dashboard")).toBeVisible();
+    await expect(page.getByText("Angular Portal")).toBeVisible();
+  });
+
+  test("renders project card with framework and language info", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+    await expect(page.getByText("Next.js · TypeScript")).toBeVisible();
+    await expect(page.getByText("React + Vite · JavaScript")).toBeVisible();
+  });
+
+  test("renders correct status badges", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+    await expect(page.getByText("Live", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText("Draft", { exact: true })).toBeVisible();
+    await expect(page.getByText("Failed", { exact: true })).toBeVisible();
+  });
+
+  test("shows empty state when no projects are returned", async ({ page }) => {
+    await mockProjectsEndpoint(page, []);
+    await page.goto("/dashboard");
+    await expect(page.getByText("No projects found matching your criteria.")).toBeVisible();
+  });
+
+  test("shows error state when API fails", async ({ page }) => {
+    await page.route("**/api/services/app/Project/GetAll", route =>
+      route.fulfill({ status: 500, body: "Internal Server Error" })
+    );
+    await page.goto("/dashboard");
+    await expect(
+      page.getByText("Failed to load projects. Please try again.")
+    ).toBeVisible();
+  });
+
+  test("renders search input", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+    await expect(page.getByPlaceholder("Search projects...")).toBeVisible();
+  });
+
+  test("search filters projects by name", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+
+    await page.getByPlaceholder("Search projects...").fill("React");
+
+    await expect(page.getByText("React Dashboard")).toBeVisible();
+    await expect(page.getByText("My Next App")).not.toBeVisible();
+    await expect(page.getByText("Angular Portal")).not.toBeVisible();
+  });
+
+  test("search is case insensitive", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+
+    await page.getByPlaceholder("Search projects...").fill("next");
+    await expect(page.getByText("My Next App")).toBeVisible();
+  });
+
+  test("search with no match shows empty state", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+
+    await page.getByPlaceholder("Search projects...").fill("zzznomatch");
+    await expect(page.getByText("No projects found matching your criteria.")).toBeVisible();
+  });
+
+  test("status filter dropdown opens when clicked", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+
+    await page.getByRole("button", { name: /All/i }).click();
+    await expect(page.getByRole("button", { name: "Draft" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Live" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Failed" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Generating" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Generated" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Deploying" })).toBeVisible();
+  });
+
+  test("status filter filters projects by status", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+
+    await page.getByRole("button", { name: /All/i }).click();
+    await page.getByRole("button", { name: "Draft" }).click();
+
+    await expect(page.getByText("React Dashboard")).toBeVisible();
+    await expect(page.getByText("My Next App")).not.toBeVisible();
+    await expect(page.getByText("Angular Portal")).not.toBeVisible();
+  });
+
+  test("status filter Live shows only live projects", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+
+    await page.getByRole("button", { name: /All/i }).click();
+    await page.getByRole("button", { name: "Live" }).click();
+
+    await expect(page.getByText("My Next App")).toBeVisible();
+    await expect(page.getByText("React Dashboard")).not.toBeVisible();
+    await expect(page.getByText("Angular Portal")).not.toBeVisible();
+  });
+
+  test("selecting a filter closes the dropdown", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+
+    await page.getByRole("button", { name: /All/i }).click();
+    await page.getByRole("button", { name: "Failed" }).click();
+
+    // Dropdown items should no longer be visible
+    await expect(page.getByRole("button", { name: "Draft" })).not.toBeVisible();
+  });
+
+  test("project card shows Open button", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+    const openButtons = page.getByRole("button", { name: "Open" });
+    await expect(openButtons.first()).toBeVisible();
+  });
+
+  test("project card shows No live URL yet when url is absent", async ({ page }) => {
+    await mockProjectsEndpoint(page, sampleProjects);
+    await page.goto("/dashboard");
+    await expect(page.getByText("No live URL yet").first()).toBeVisible();
+  });
+});

--- a/frontend/tests/e2e/landing.spec.ts
+++ b/frontend/tests/e2e/landing.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Landing page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("renders PromptForge logo and brand name in nav", async ({ page }) => {
+    await expect(page.getByRole("navigation").getByText("PromptForge")).toBeVisible();
+  });
+
+  test("renders Sign in and Get Started nav buttons", async ({ page }) => {
+    await expect(page.getByRole("link", { name: "Sign in" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Get Started" })).toBeVisible();
+  });
+
+  test("Sign in and Get Started nav links point to /auth", async ({ page }) => {
+    const signInLink = page.getByRole("link", { name: "Sign in" });
+    const getStartedLink = page.getByRole("link", { name: "Get Started" });
+    await expect(signInLink).toHaveAttribute("href", "/auth");
+    await expect(getStartedLink).toHaveAttribute("href", "/auth");
+  });
+
+  test("renders hero tag and title", async ({ page }) => {
+    await expect(page.getByText("prompt → code → deploy")).toBeVisible();
+    await expect(page.getByRole("heading", { name: /From idea to/i })).toBeVisible();
+    await expect(page.getByText("live app")).toBeVisible();
+  });
+
+  test("renders hero subtitle", async ({ page }) => {
+    await expect(
+      page.getByText("Describe your application in plain English")
+    ).toBeVisible();
+  });
+
+  test("renders prompt input card with Generate App button", async ({ page }) => {
+    await expect(page.getByPlaceholder(/Generate a project management tool/)).toBeVisible();
+    await expect(page.getByRole("button", { name: "Generate App" })).toBeVisible();
+  });
+
+  test("renders all four feature cards", async ({ page }) => {
+    await expect(page.getByText("Prompt-Driven")).toBeVisible();
+    await expect(page.getByText("GitHub Integration")).toBeVisible();
+    await expect(page.getByText("Auto Deploy")).toBeVisible();
+    await expect(page.getByText("Iterative Refinement")).toBeVisible();
+  });
+
+  test("renders intelligent pipeline section title", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: /Intelligent/i })).toBeVisible();
+    await expect(page.getByText("promptforge — generation pipeline")).toBeVisible();
+  });
+
+  test("renders pipeline steps", async ({ page }) => {
+    await expect(page.getByText("Parse requirements")).toBeVisible();
+    await expect(page.getByText("Generate frontend")).toBeVisible();
+    await expect(page.getByText("Generate backend & API")).toBeVisible();
+    await expect(page.getByText("Create GitHub repository")).toBeVisible();
+    await expect(page.getByText("Push code & commit")).toBeVisible();
+    await expect(page.getByText("Deploy to production")).toBeVisible();
+  });
+
+  test("renders footer with PromptForge branding", async ({ page }) => {
+    await expect(page.getByText("Built for builders.")).toBeVisible();
+  });
+});

--- a/frontend/tests/e2e/register.spec.ts
+++ b/frontend/tests/e2e/register.spec.ts
@@ -1,0 +1,190 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Register page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/register");
+  });
+
+  test("renders Create your account heading and subtitle", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: "Create your account" })).toBeVisible();
+    await expect(page.getByText("Start building with PromptForge")).toBeVisible();
+  });
+
+  test("renders all form fields", async ({ page }) => {
+    await expect(page.getByPlaceholder("First name")).toBeVisible();
+    await expect(page.getByPlaceholder("Surname")).toBeVisible();
+    await expect(page.getByPlaceholder("Username")).toBeVisible();
+    await expect(page.getByPlaceholder("Email address")).toBeVisible();
+    await expect(page.getByPlaceholder("Create a password")).toBeVisible();
+    await expect(page.getByPlaceholder("Confirm password")).toBeVisible();
+  });
+
+  test("renders Sign up with GitHub button", async ({ page }) => {
+    await expect(page.getByRole("button", { name: /Sign up with GitHub/i })).toBeVisible();
+  });
+
+  test("Create account button is disabled when fields are empty", async ({ page }) => {
+    await expect(page.getByRole("button", { name: "Create account" })).toBeDisabled();
+  });
+
+  test("Create account button stays disabled with partial fields", async ({ page }) => {
+    await page.getByPlaceholder("First name").fill("Jane");
+    await page.getByPlaceholder("Surname").fill("Doe");
+    // Missing email, password, confirm
+    await expect(page.getByRole("button", { name: "Create account" })).toBeDisabled();
+  });
+
+  test("password strength checks appear when typing password", async ({ page }) => {
+    await page.getByPlaceholder("Create a password").fill("a");
+    await expect(page.getByText("At least 8 characters")).toBeVisible();
+    await expect(page.getByText("One uppercase letter")).toBeVisible();
+    await expect(page.getByText("One number or symbol")).toBeVisible();
+  });
+
+  test("password check for 8 characters becomes met", async ({ page }) => {
+    await page.getByPlaceholder("Create a password").fill("Password1!");
+    // All three checks should be met - look for the check items text
+    await expect(page.getByText("At least 8 characters")).toBeVisible();
+    await expect(page.getByText("One uppercase letter")).toBeVisible();
+    await expect(page.getByText("One number or symbol")).toBeVisible();
+  });
+
+  test("Passwords match check appears when confirm password is typed", async ({ page }) => {
+    await page.getByPlaceholder("Create a password").fill("Password1!");
+    await page.getByPlaceholder("Confirm password").fill("Password1!");
+    await expect(page.getByText("Passwords match")).toBeVisible();
+  });
+
+  test("Create account button stays disabled when passwords do not match", async ({ page }) => {
+    await page.getByPlaceholder("First name").fill("Jane");
+    await page.getByPlaceholder("Surname").fill("Doe");
+    await page.getByPlaceholder("Username").fill("jane.doe");
+    await page.getByPlaceholder("Email address").fill("jane@example.com");
+    await page.getByPlaceholder("Create a password").fill("Password1!");
+    await page.getByPlaceholder("Confirm password").fill("Different1!");
+    await expect(page.getByRole("button", { name: "Create account" })).toBeDisabled();
+  });
+
+  test("Create account button is enabled when all valid fields are filled", async ({ page }) => {
+    await page.getByPlaceholder("First name").fill("Jane");
+    await page.getByPlaceholder("Surname").fill("Doe");
+    await page.getByPlaceholder("Username").fill("jane.doe");
+    await page.getByPlaceholder("Email address").fill("jane@example.com");
+    await page.getByPlaceholder("Create a password").fill("Password1!");
+    await page.getByPlaceholder("Confirm password").fill("Password1!");
+    await expect(page.getByRole("button", { name: "Create account" })).toBeEnabled();
+  });
+
+  test("shows sign in link pointing to /login", async ({ page }) => {
+    const signInLink = page.getByRole("link", { name: "Sign in" });
+    await expect(signInLink).toBeVisible();
+    await expect(signInLink).toHaveAttribute("href", "/login");
+  });
+
+  test("shows terms of service and privacy policy text", async ({ page }) => {
+    await expect(page.getByText("Terms of Service")).toBeVisible();
+    await expect(page.getByText("Privacy Policy")).toBeVisible();
+  });
+
+  test("shows error message after failed registration", async ({ page }) => {
+    await page.route("**/api/services/app/Account/Register", route =>
+      route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { message: "User already exists" } }),
+      })
+    );
+
+    await page.getByPlaceholder("First name").fill("Jane");
+    await page.getByPlaceholder("Surname").fill("Doe");
+    await page.getByPlaceholder("Username").fill("jane.doe");
+    await page.getByPlaceholder("Email address").fill("jane@example.com");
+    await page.getByPlaceholder("Create a password").fill("Password1!");
+    await page.getByPlaceholder("Confirm password").fill("Password1!");
+
+    await Promise.all([
+      page.waitForRequest("**/api/services/app/Account/Register"),
+      page.getByRole("button", { name: "Create account" }).click(),
+    ]);
+
+    await expect(
+      page.getByText("Registration failed. Please check your details.")
+    ).toBeVisible();
+  });
+
+  test("sends Abp.TenantId header when tenant param is present", async ({ page }) => {
+    let tenantHeader: string | undefined;
+
+    await page.route("**/api/services/app/Account/Register", route => {
+      tenantHeader = route.request().headers()["abp.tenantid"];
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ result: {} }),
+      });
+    });
+
+    await page.route("**/api/TokenAuth/Authenticate", route =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          result: { accessToken: "token-123", expireInSeconds: 3600, userId: 7 },
+        }),
+      })
+    );
+
+    await page.goto("/register?tenant=Nw==");
+
+    await page.getByPlaceholder("First name").fill("Jane");
+    await page.getByPlaceholder("Surname").fill("Doe");
+    await page.getByPlaceholder("Username").fill("jane.doe");
+    await page.getByPlaceholder("Email address").fill("jane@example.com");
+    await page.getByPlaceholder("Create a password").fill("Password1!");
+    await page.getByPlaceholder("Confirm password").fill("Password1!");
+
+    await Promise.all([
+      page.waitForRequest("**/api/services/app/Account/Register"),
+      page.getByRole("button", { name: "Create account" }).click(),
+    ]);
+
+    expect(tenantHeader).toBe("7");
+  });
+
+  test("does not send Abp.TenantId header when no tenant param", async ({ page }) => {
+    let tenantHeader: string | undefined;
+
+    await page.route("**/api/services/app/Account/Register", route => {
+      tenantHeader = route.request().headers()["abp.tenantid"];
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ result: {} }),
+      });
+    });
+
+    await page.route("**/api/TokenAuth/Authenticate", route =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          result: { accessToken: "token-123", expireInSeconds: 3600, userId: 7 },
+        }),
+      })
+    );
+
+    await page.getByPlaceholder("First name").fill("Jane");
+    await page.getByPlaceholder("Surname").fill("Doe");
+    await page.getByPlaceholder("Username").fill("jane.doe");
+    await page.getByPlaceholder("Email address").fill("jane@example.com");
+    await page.getByPlaceholder("Create a password").fill("Password1!");
+    await page.getByPlaceholder("Confirm password").fill("Password1!");
+
+    await Promise.all([
+      page.waitForRequest("**/api/services/app/Account/Register"),
+      page.getByRole("button", { name: "Create account" }).click(),
+    ]);
+
+    expect(tenantHeader).toBeUndefined();
+  });
+});

--- a/frontend/tests/e2e/signin.spec.ts
+++ b/frontend/tests/e2e/signin.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Sign in page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/login");
+  });
+
+  test("renders Welcome back heading and subtitle", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+    await expect(page.getByText("Sign in to your PromptForge account")).toBeVisible();
+  });
+
+  test("renders email and password inputs", async ({ page }) => {
+    await expect(page.getByPlaceholder("Email address")).toBeVisible();
+    await expect(page.getByPlaceholder("Password")).toBeVisible();
+  });
+
+  test("renders Continue with GitHub button", async ({ page }) => {
+    await expect(page.getByRole("button", { name: /Continue with GitHub/i })).toBeVisible();
+  });
+
+  test("sign in button is disabled when fields are empty", async ({ page }) => {
+    const signInBtn = page.getByRole("button", { name: "Sign in" });
+    await expect(signInBtn).toBeDisabled();
+  });
+
+  test("sign in button becomes enabled when both fields are filled", async ({ page }) => {
+    await page.getByPlaceholder("Email address").fill("user@example.com");
+    await page.getByPlaceholder("Password").fill("Password1!");
+    await expect(page.getByRole("button", { name: "Sign in" })).toBeEnabled();
+  });
+
+  test("shows validation error when submitting empty form via keyboard", async ({ page }) => {
+    // Type and then clear to trigger attempted state, or click anyway
+    await page.getByPlaceholder("Email address").fill("x");
+    await page.getByPlaceholder("Email address").clear();
+    await page.getByPlaceholder("Password").fill("x");
+    await page.getByPlaceholder("Password").clear();
+
+    // Force click the disabled button by evaluating the handler directly isn't ideal;
+    // instead we rely on the validation path by filling in partial data
+    await page.getByPlaceholder("Email address").fill("user@example.com");
+    // password still empty — button should be disabled
+    await expect(page.getByRole("button", { name: "Sign in" })).toBeDisabled();
+  });
+
+  test("shows sign up link pointing to /register", async ({ page }) => {
+    const signUpLink = page.getByRole("link", { name: "Sign up" });
+    await expect(signUpLink).toBeVisible();
+    await expect(signUpLink).toHaveAttribute("href", "/register");
+  });
+
+  test("clicking Forgot password? switches to forgot password view", async ({ page }) => {
+    await page.getByRole("button", { name: "Forgot password?" }).click();
+    await expect(page.getByRole("heading", { name: "Reset your password" })).toBeVisible();
+    await expect(
+      page.getByText("Enter the email address linked to your account")
+    ).toBeVisible();
+  });
+
+  test("forgot password view has Back to sign in button", async ({ page }) => {
+    await page.getByRole("button", { name: "Forgot password?" }).click();
+    await expect(page.getByRole("button", { name: /Back to sign in/i })).toBeVisible();
+  });
+
+  test("Back to sign in returns to sign in view", async ({ page }) => {
+    await page.getByRole("button", { name: "Forgot password?" }).click();
+    await page.getByRole("button", { name: /Back to sign in/i }).click();
+    await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+  });
+
+  test("forgot password shows success state after entering email", async ({ page }) => {
+    await page.getByRole("button", { name: "Forgot password?" }).click();
+    await page.getByPlaceholder("Email address").fill("user@example.com");
+    await page.getByRole("button", { name: "Send reset link" }).click();
+    await expect(page.getByRole("heading", { name: "Check your email" })).toBeVisible();
+    await expect(page.getByText("user@example.com")).toBeVisible();
+  });
+
+  test("forgot password success state shows Try again link", async ({ page }) => {
+    await page.getByRole("button", { name: "Forgot password?" }).click();
+    await page.getByPlaceholder("Email address").fill("user@example.com");
+    await page.getByRole("button", { name: "Send reset link" }).click();
+    await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
+  });
+
+  test("Try again returns to forgot password form", async ({ page }) => {
+    await page.getByRole("button", { name: "Forgot password?" }).click();
+    await page.getByPlaceholder("Email address").fill("user@example.com");
+    await page.getByRole("button", { name: "Send reset link" }).click();
+    await page.getByRole("button", { name: "Try again" }).click();
+    await expect(page.getByRole("heading", { name: "Reset your password" })).toBeVisible();
+  });
+
+  test("shows error message after failed sign in attempt", async ({ page }) => {
+    await page.route("**/api/TokenAuth/Authenticate", route =>
+      route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { message: "Invalid credentials" } }),
+      })
+    );
+
+    await page.getByPlaceholder("Email address").fill("bad@example.com");
+    await page.getByPlaceholder("Password").fill("wrongpassword");
+    await Promise.all([
+      page.waitForRequest("**/api/TokenAuth/Authenticate"),
+      page.getByRole("button", { name: "Sign in" }).click(),
+    ]);
+    await expect(page.getByText("Invalid credentials. Please try again.")).toBeVisible();
+  });
+
+  test("send reset link button is disabled when email is empty", async ({ page }) => {
+    await page.getByRole("button", { name: "Forgot password?" }).click();
+    // The button calls `email && setSent(true)` — clicking with empty email does nothing
+    const sendBtn = page.getByRole("button", { name: "Send reset link" });
+    await sendBtn.click();
+    // Should still be on the forgot password form, not the success state
+    await expect(page.getByRole("heading", { name: "Reset your password" })).toBeVisible();
+  });
+});


### PR DESCRIPTION
This pull request introduces a comprehensive suite of end-to-end tests for the frontend application using Playwright. It covers core user flows for the landing page, dashboard, registration, and sign-in pages, ensuring robust validation of UI elements, user interactions, and API integration. Additionally, the Playwright configuration is updated to improve test reliability and performance.

**E2E Test Coverage Enhancements**

* Added full end-to-end tests for the landing page, verifying navigation, branding, feature cards, pipeline steps, and footer elements in `landing.spec.ts`.
* Introduced extensive dashboard tests in `dashboard.spec.ts`, covering authentication, project listing, loading/error/empty states, search/filter functionality, and project card UI.
* Implemented detailed registration page tests in `register.spec.ts`, including form validation, password strength checks, error handling, tenant header logic, and successful registration flows.
* Added sign-in page tests in `signin.spec.ts`, validating form controls, error states, forgot password flows, and navigation links.

**Playwright Configuration Improvements**

* Updated `playwright.config.ts` to increase test timeout, enable retries, and set worker count for improved reliability and parallel execution.