### PR TITLE
Add templates provider and templates page

### DIFF
--- a/frontend/src/app/(main)/templates/page.test.tsx
+++ b/frontend/src/app/(main)/templates/page.test.tsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import TemplatesPage from "./page";
+
+const fetchAllMock = vi.hoisted(() => vi.fn());
+const templateStateMock = vi.hoisted(() => ({
+  items: [] as Array<{
+    id: number;
+    name: string;
+    slug: string;
+    category: string;
+    description?: string | null;
+    tags?: string | null;
+    author?: string | null;
+    likeCount?: number | null;
+    viewCount?: number | null;
+    sourceUrl?: string | null;
+  }>,
+  isPending: false,
+  isError: false,
+}));
+
+vi.mock("@/providers/templates-provider", () => ({
+  useTemplateAction: () => ({
+    fetchAll: fetchAllMock,
+  }),
+  useTemplateState: () => templateStateMock,
+}));
+
+vi.mock("./styles/style", () => ({
+  useStyles: () => ({
+    styles: new Proxy(
+      {},
+      {
+        get: (_target, key) => String(key),
+      },
+    ),
+  }),
+}));
+
+describe("TemplatesPage", () => {
+  beforeEach(() => {
+    fetchAllMock.mockReset();
+    templateStateMock.items = [];
+    templateStateMock.isPending = false;
+    templateStateMock.isError = false;
+  });
+
+  it("loads templates on mount and filters by search", () => {
+    templateStateMock.items = [
+      {
+        id: 1,
+        name: "Admin Dashboard",
+        slug: "admin-dashboard",
+        category: "Internal",
+        description: "Internal analytics dashboard template",
+        tags: "admin,analytics",
+      },
+      {
+        id: 2,
+        name: "Marketing Landing",
+        slug: "marketing-landing",
+        category: "Marketing",
+        description: "Landing page starter",
+        tags: "landing,seo",
+      },
+    ];
+
+    render(<TemplatesPage />);
+
+    expect(fetchAllMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Admin Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Marketing Landing")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("Search templates"), {
+      target: { value: "marketing" },
+    });
+
+    expect(screen.getByText("Marketing Landing")).toBeInTheDocument();
+    expect(screen.queryByText("Admin Dashboard")).not.toBeInTheDocument();
+  });
+
+  it("shows error empty state when loading fails", () => {
+    templateStateMock.isError = true;
+
+    render(<TemplatesPage />);
+
+    expect(fetchAllMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Could not load templates.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(main)/templates/page.tsx
+++ b/frontend/src/app/(main)/templates/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button, Card, Empty, Input, Select, Spin, Tag } from "antd";
+import { useTemplateAction, useTemplateState } from "@/providers/templates-provider";
+import { useStyles } from "./styles/style";
+
+export default function TemplatesPage() {
+  const { styles } = useStyles();
+  const { fetchAll } = useTemplateAction();
+  const { items, isPending, isError } = useTemplateState();
+  const [searchTerm, setSearchTerm] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState<string>("all");
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  const categories = useMemo(() => {
+    const categoryOptions = Array.from(
+      new Set(items.map((template) => template.category).filter(Boolean)),
+    ).sort((first, second) => first.localeCompare(second));
+
+    return [{ label: "All categories", value: "all" }].concat(
+      categoryOptions.map((category) => ({ label: category, value: category })),
+    );
+  }, [items]);
+
+  const filteredItems = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+
+    return items.filter((template) => {
+      const matchesCategory =
+        categoryFilter === "all" || template.category === categoryFilter;
+
+      if (!matchesCategory) {
+        return false;
+      }
+
+      if (!query) {
+        return true;
+      }
+
+      const content = [
+        template.name,
+        template.slug,
+        template.description,
+        template.category,
+        template.tags,
+        template.author,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+
+      return content.includes(query);
+    });
+  }, [categoryFilter, items, searchTerm]);
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.toolbar}>
+        <div className={styles.titleWrap}>
+          <h1 className={styles.title}>Templates</h1>
+          <p className={styles.subtitle}>
+            Browse backend templates and use them as starting points for generation.
+          </p>
+        </div>
+
+        <div className={styles.controls}>
+          <Input.Search
+            allowClear
+            placeholder="Search templates"
+            className={styles.search}
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+          />
+          <Select
+            value={categoryFilter}
+            options={categories}
+            onChange={(value) => setCategoryFilter(value)}
+          />
+          <Button onClick={() => fetchAll()} loading={isPending}>
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      {isPending && items.length === 0 ? (
+        <Card className={styles.stateCard}>
+          <div className={styles.stateInner}>
+            <Spin size="large" />
+          </div>
+        </Card>
+      ) : isError && items.length === 0 ? (
+        <Card className={styles.stateCard}>
+          <div className={styles.stateInner}>
+            <Empty
+              description="Could not load templates."
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            />
+          </div>
+        </Card>
+      ) : filteredItems.length === 0 ? (
+        <Card className={styles.stateCard}>
+          <div className={styles.stateInner}>
+            <Empty
+              description="No templates match your filters."
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            />
+          </div>
+        </Card>
+      ) : (
+        <div className={styles.grid}>
+          {filteredItems.map((template) => {
+            const tagList = (template.tags ?? "")
+              .split(",")
+              .map((tag) => tag.trim())
+              .filter(Boolean)
+              .slice(0, 4);
+
+            return (
+              <Card key={template.id} className={styles.templateCard}>
+                <div className={styles.templateHeader}>
+                  <h2 className={styles.templateName}>{template.name}</h2>
+                  <Tag>{template.category}</Tag>
+                </div>
+
+                <p className={styles.description}>
+                  {template.description?.trim() || "No description provided."}
+                </p>
+
+                <div className={styles.metaGrid}>
+                  <div className={styles.metaItem}>
+                    <span className={styles.metaLabel}>Author</span>
+                    <span className={styles.metaValue}>{template.author || "Unknown"}</span>
+                  </div>
+                  <div className={styles.metaItem}>
+                    <span className={styles.metaLabel}>Slug</span>
+                    <span className={styles.metaValue}>{template.slug}</span>
+                  </div>
+                  <div className={styles.metaItem}>
+                    <span className={styles.metaLabel}>Likes</span>
+                    <span className={styles.metaValue}>{template.likeCount ?? 0}</span>
+                  </div>
+                  <div className={styles.metaItem}>
+                    <span className={styles.metaLabel}>Views</span>
+                    <span className={styles.metaValue}>{template.viewCount ?? 0}</span>
+                  </div>
+                </div>
+
+                {tagList.length > 0 && (
+                  <div className={styles.tagsRow}>
+                    {tagList.map((tag) => (
+                      <Tag key={`${template.id}-${tag}`}>{tag}</Tag>
+                    ))}
+                  </div>
+                )}
+
+                {template.sourceUrl && (
+                  <a
+                    href={template.sourceUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={styles.sourceLink}
+                  >
+                    View source
+                  </a>
+                )}
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/(main)/templates/styles/style.ts
+++ b/frontend/src/app/(main)/templates/styles/style.ts
@@ -1,0 +1,120 @@
+import { createStyles } from "antd-style";
+
+export const useStyles = createStyles(({ token, css }) => ({
+  page: css`
+    min-height: 100vh;
+    padding: ${token.paddingXL}px;
+    background: ${token.colorBgLayout};
+  `,
+  toolbar: css`
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: ${token.margin}px;
+    margin-bottom: ${token.marginLG}px;
+  `,
+  titleWrap: css`
+    display: flex;
+    flex-direction: column;
+    gap: ${token.marginSM / 2}px;
+  `,
+  title: css`
+    margin: 0;
+    font-size: ${token.fontSizeXL}px;
+    font-weight: ${token.fontWeightStrong};
+    color: ${token.colorText};
+  `,
+  subtitle: css`
+    margin: 0;
+    color: ${token.colorTextSecondary};
+    font-size: ${token.fontSize}px;
+  `,
+  controls: css`
+    display: flex;
+    align-items: center;
+    gap: ${token.marginSM}px;
+    flex-wrap: wrap;
+  `,
+  search: css`
+    width: ${token.paddingXL * 10}px;
+    max-width: 100%;
+  `,
+  stateCard: css`
+    border-radius: ${token.borderRadiusLG}px;
+    border-color: ${token.colorBorder};
+    background: ${token.colorBgContainer};
+  `,
+  stateInner: css`
+    min-height: ${token.paddingXL * 8}px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  `,
+  grid: css`
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(${token.paddingXL * 10}px, 1fr));
+    gap: ${token.marginLG}px;
+  `,
+  templateCard: css`
+    height: 100%;
+    border-radius: ${token.borderRadiusLG}px;
+    border-color: ${token.colorBorder};
+    background: ${token.colorBgContainer};
+  `,
+  templateHeader: css`
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: ${token.marginSM}px;
+  `,
+  templateName: css`
+    margin: 0;
+    color: ${token.colorText};
+    font-size: ${token.fontSizeLG}px;
+    font-weight: ${token.fontWeightStrong};
+  `,
+  description: css`
+    margin: ${token.marginSM}px 0 ${token.margin}px;
+    color: ${token.colorTextSecondary};
+    font-size: ${token.fontSize}px;
+    line-height: 1.5;
+    min-height: ${token.paddingXL * 2}px;
+  `,
+  metaGrid: css`
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: ${token.marginSM}px;
+    margin-bottom: ${token.margin}px;
+  `,
+  metaItem: css`
+    display: flex;
+    flex-direction: column;
+    gap: ${token.marginSM / 3}px;
+  `,
+  metaLabel: css`
+    color: ${token.colorTextSecondary};
+    font-size: ${token.fontSizeSM}px;
+  `,
+  metaValue: css`
+    color: ${token.colorText};
+    font-size: ${token.fontSize}px;
+    font-weight: ${token.fontWeightStrong};
+  `,
+  tagsRow: css`
+    display: flex;
+    flex-wrap: wrap;
+    gap: ${token.marginSM / 2}px;
+    margin-bottom: ${token.margin}px;
+  `,
+  sourceLink: css`
+    color: ${token.colorPrimary};
+    font-size: ${token.fontSizeSM}px;
+    font-weight: ${token.fontWeightStrong};
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  `,
+}));

--- a/frontend/src/components/Sidebar/index.tsx
+++ b/frontend/src/components/Sidebar/index.tsx
@@ -3,6 +3,7 @@
 import {
   LayoutGridIcon,
   FolderIcon,
+  LayoutTemplateIcon,
   SettingsIcon,
   PlusIcon,
   ChevronDownIcon,
@@ -38,6 +39,11 @@ export function Sidebar({ currentPage, onNavigate }: SidebarProps) {
       id: "projects",
       label: "My Projects",
       icon: FolderIcon,
+    },
+    {
+      id: "templates",
+      label: "Templates",
+      icon: LayoutTemplateIcon,
     },
     {
       id: "settings",
@@ -102,9 +108,7 @@ export function Sidebar({ currentPage, onNavigate }: SidebarProps) {
               <button
                 key={item.id}
                 type="button"
-                onClick={() =>
-                  onNavigate(item.id === "projects" ? "dashboard" : item.id)
-                }
+                onClick={() => onNavigate(item.id === "projects" ? "dashboard" : item.id)}
                 className={cx(
                   styles.navButton,
                   styles.focusRing,

--- a/frontend/src/providers/index.tsx
+++ b/frontend/src/providers/index.tsx
@@ -2,6 +2,7 @@
 
 import { AuthProvider } from "./auth-provider";
 import { ProjectProvider } from "./projects-provider";
+import { TemplateProvider } from "./templates-provider";
 
 interface AppProvidersProps {
   children: React.ReactNode;
@@ -10,7 +11,9 @@ interface AppProvidersProps {
 export const AppProviders: React.FC<AppProvidersProps> = ({ children }) => {
   return (
     <AuthProvider>
-      <ProjectProvider>{children}</ProjectProvider>
+      <ProjectProvider>
+        <TemplateProvider>{children}</TemplateProvider>
+      </ProjectProvider>
     </AuthProvider>
   );
 };

--- a/frontend/src/providers/templates-provider/actions.tsx
+++ b/frontend/src/providers/templates-provider/actions.tsx
@@ -1,0 +1,114 @@
+import { createAction } from "redux-actions";
+import { ITemplateItem, ITemplateStateContext } from "./context";
+
+type TemplateStatePayload = Partial<ITemplateStateContext>;
+
+export enum TemplateStateEnums {
+  TEMPLATE_FETCH_ALL_PENDING = "TEMPLATE_FETCH_ALL_PENDING",
+  TEMPLATE_FETCH_ALL_SUCCESS = "TEMPLATE_FETCH_ALL_SUCCESS",
+  TEMPLATE_FETCH_ALL_ERROR = "TEMPLATE_FETCH_ALL_ERROR",
+  TEMPLATE_FETCH_ONE_PENDING = "TEMPLATE_FETCH_ONE_PENDING",
+  TEMPLATE_FETCH_ONE_SUCCESS = "TEMPLATE_FETCH_ONE_SUCCESS",
+  TEMPLATE_FETCH_ONE_ERROR = "TEMPLATE_FETCH_ONE_ERROR",
+  TEMPLATE_CREATE_PENDING = "TEMPLATE_CREATE_PENDING",
+  TEMPLATE_CREATE_SUCCESS = "TEMPLATE_CREATE_SUCCESS",
+  TEMPLATE_CREATE_ERROR = "TEMPLATE_CREATE_ERROR",
+  TEMPLATE_UPDATE_PENDING = "TEMPLATE_UPDATE_PENDING",
+  TEMPLATE_UPDATE_SUCCESS = "TEMPLATE_UPDATE_SUCCESS",
+  TEMPLATE_UPDATE_ERROR = "TEMPLATE_UPDATE_ERROR",
+  TEMPLATE_DELETE_PENDING = "TEMPLATE_DELETE_PENDING",
+  TEMPLATE_DELETE_SUCCESS = "TEMPLATE_DELETE_SUCCESS",
+  TEMPLATE_DELETE_ERROR = "TEMPLATE_DELETE_ERROR",
+}
+
+export const fetchAllPending = createAction<TemplateStatePayload>(
+  TemplateStateEnums.TEMPLATE_FETCH_ALL_PENDING,
+  () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const fetchAllSuccess = createAction(
+  TemplateStateEnums.TEMPLATE_FETCH_ALL_SUCCESS,
+  ({
+    items,
+    totalCount,
+  }: {
+    items: ITemplateItem[];
+    totalCount: number;
+  }): TemplateStatePayload => ({
+    isPending: false,
+    isSuccess: true,
+    isError: false,
+    items,
+    totalCount,
+  }),
+);
+
+export const fetchAllError = createAction<TemplateStatePayload>(
+  TemplateStateEnums.TEMPLATE_FETCH_ALL_ERROR,
+  () => ({ isPending: false, isSuccess: false, isError: true }),
+);
+
+export const fetchOnePending = createAction<TemplateStatePayload>(
+  TemplateStateEnums.TEMPLATE_FETCH_ONE_PENDING,
+  () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const fetchOneSuccess = createAction(
+  TemplateStateEnums.TEMPLATE_FETCH_ONE_SUCCESS,
+  (selected: ITemplateItem): TemplateStatePayload => ({
+    isPending: false,
+    isSuccess: true,
+    isError: false,
+    selected,
+  }),
+);
+
+export const fetchOneError = createAction<TemplateStatePayload>(
+  TemplateStateEnums.TEMPLATE_FETCH_ONE_ERROR,
+  () => ({ isPending: false, isSuccess: false, isError: true }),
+);
+
+export const createPending = createAction<TemplateStatePayload>(
+  TemplateStateEnums.TEMPLATE_CREATE_PENDING,
+  () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const createSuccess = createAction<TemplateStatePayload>(
+  TemplateStateEnums.TEMPLATE_CREATE_SUCCESS,
+  () => ({ isPending: false, isSuccess: true, isError: false }),
+);
+
+export const createError = createAction<TemplateStatePayload>(
+  TemplateStateEnums.TEMPLATE_CREATE_ERROR,
+  () => ({ isPending: false, isSuccess: false, isError: true }),
+);
+
+export const updatePending = createAction<TemplateStatePayload>(
+  TemplateStateEnums.TEMPLATE_UPDATE_PENDING,
+  () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const updateSuccess = createAction<TemplateStatePayload>(
+  TemplateStateEnums.TEMPLATE_UPDATE_SUCCESS,
+  () => ({ isPending: false, isSuccess: true, isError: false }),
+);
+
+export const updateError = createAction<TemplateStatePayload>(
+  TemplateStateEnums.TEMPLATE_UPDATE_ERROR,
+  () => ({ isPending: false, isSuccess: false, isError: true }),
+);
+
+export const deletePending = createAction<TemplateStatePayload>(
+  TemplateStateEnums.TEMPLATE_DELETE_PENDING,
+  () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const deleteSuccess = createAction<TemplateStatePayload>(
+  TemplateStateEnums.TEMPLATE_DELETE_SUCCESS,
+  () => ({ isPending: false, isSuccess: true, isError: false }),
+);
+
+export const deleteError = createAction<TemplateStatePayload>(
+  TemplateStateEnums.TEMPLATE_DELETE_ERROR,
+  () => ({ isPending: false, isSuccess: false, isError: true }),
+);

--- a/frontend/src/providers/templates-provider/context.tsx
+++ b/frontend/src/providers/templates-provider/context.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { createContext } from "react";
+
+export interface ITemplateItem {
+  id: number;
+  name: string;
+  slug: string;
+  description?: string | null;
+  previewImageUrl?: string | null;
+  category: string;
+  tags?: string | null;
+  author?: string | null;
+  sourceUrl?: string | null;
+  lastUpdatedAt?: string | null;
+  likeCount?: number | null;
+  viewCount?: number | null;
+}
+
+export interface ITemplateCreateInput {
+  name: string;
+  slug: string;
+  description?: string;
+  previewImageUrl?: string;
+  category: string;
+  tags?: string;
+  author?: string;
+  sourceUrl?: string;
+  lastUpdatedAt?: string | null;
+  likeCount?: number | null;
+  viewCount?: number | null;
+}
+
+export interface ITemplateUpdateInput extends ITemplateCreateInput {
+  id: number;
+}
+
+export interface ITemplateStateContext {
+  isPending: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+  items: ITemplateItem[];
+  selected?: ITemplateItem;
+  totalCount: number;
+}
+
+export interface ITemplateActionContext {
+  fetchAll: () => Promise<void>;
+  fetchById: (id: number) => Promise<void>;
+  create: (data: ITemplateCreateInput) => Promise<void>;
+  update: (data: ITemplateUpdateInput) => Promise<void>;
+  remove: (id: number) => Promise<void>;
+}
+
+export const INITIAL_STATE: ITemplateStateContext = {
+  isPending: false,
+  isSuccess: false,
+  isError: false,
+  items: [],
+  totalCount: 0,
+};
+
+export const TemplateStateContext =
+  createContext<ITemplateStateContext>(INITIAL_STATE);
+export const TemplateActionContext = createContext<ITemplateActionContext>({
+  fetchAll: async () => {},
+  fetchById: async () => {},
+  create: async () => {},
+  update: async () => {},
+  remove: async () => {},
+});

--- a/frontend/src/providers/templates-provider/index.test.tsx
+++ b/frontend/src/providers/templates-provider/index.test.tsx
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { TemplateProvider, useTemplateAction, useTemplateState } from "./index";
+
+const getMock = vi.hoisted(() => vi.fn());
+const postMock = vi.hoisted(() => vi.fn());
+const putMock = vi.hoisted(() => vi.fn());
+const deleteMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/utils/axiosInstance", () => ({
+  getAxiosInstance: () => ({
+    get: getMock,
+    post: postMock,
+    put: putMock,
+    delete: deleteMock,
+  }),
+}));
+
+describe("TemplateProvider actions", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    postMock.mockReset();
+    putMock.mockReset();
+    deleteMock.mockReset();
+  });
+
+  it("fetchAll loads templates into state", async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        result: {
+          items: [
+            {
+              id: 11,
+              name: "Admin Dashboard",
+              slug: "admin-dashboard",
+              category: "Internal",
+            },
+          ],
+          totalCount: 1,
+        },
+      },
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TemplateProvider>{children}</TemplateProvider>
+    );
+
+    const { result } = renderHook(
+      () => ({
+        actions: useTemplateAction(),
+        state: useTemplateState(),
+      }),
+      {
+        wrapper,
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.fetchAll();
+    });
+
+    expect(getMock).toHaveBeenCalledWith("/api/services/app/Template/GetAll");
+    expect(result.current.state.items).toHaveLength(1);
+    expect(result.current.state.totalCount).toBe(1);
+    expect(result.current.state.isSuccess).toBe(true);
+  });
+
+  it("create posts data and refreshes list", async () => {
+    postMock.mockResolvedValueOnce({ data: { result: {} } });
+    getMock.mockResolvedValueOnce({
+      data: {
+        result: {
+          items: [
+            {
+              id: 3,
+              name: "Marketing Site",
+              slug: "marketing-site",
+              category: "Marketing",
+            },
+          ],
+          totalCount: 1,
+        },
+      },
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TemplateProvider>{children}</TemplateProvider>
+    );
+
+    const { result } = renderHook(
+      () => ({
+        actions: useTemplateAction(),
+        state: useTemplateState(),
+      }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.actions.create({
+        name: "Marketing Site",
+        slug: "marketing-site",
+        category: "Marketing",
+      });
+    });
+
+    expect(postMock).toHaveBeenCalledWith("/api/services/app/Template/Create", {
+      name: "Marketing Site",
+      slug: "marketing-site",
+      category: "Marketing",
+    });
+    expect(getMock).toHaveBeenCalledWith("/api/services/app/Template/GetAll");
+    expect(result.current.state.items).toHaveLength(1);
+    expect(result.current.state.totalCount).toBe(1);
+    expect(result.current.state.isSuccess).toBe(true);
+  });
+
+  it("sets error state when fetchAll request fails", async () => {
+    getMock.mockRejectedValueOnce(new Error("network error"));
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TemplateProvider>{children}</TemplateProvider>
+    );
+
+    const { result } = renderHook(
+      () => ({
+        actions: useTemplateAction(),
+        state: useTemplateState(),
+      }),
+      {
+        wrapper,
+      },
+    );
+
+    await act(async () => {
+      await result.current.actions.fetchAll();
+    });
+
+    expect(result.current.state.isError).toBe(true);
+    expect(result.current.state.isPending).toBe(false);
+  });
+});

--- a/frontend/src/providers/templates-provider/index.tsx
+++ b/frontend/src/providers/templates-provider/index.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { ReactNode, useCallback, useContext, useReducer } from "react";
+import { getAxiosInstance } from "@/utils/axiosInstance";
+import { TemplateReducer } from "./reducer";
+import {
+  INITIAL_STATE,
+  ITemplateCreateInput,
+  ITemplateItem,
+  ITemplateUpdateInput,
+  TemplateActionContext,
+  TemplateStateContext,
+} from "./context";
+import {
+  createError,
+  createPending,
+  createSuccess,
+  deleteError,
+  deletePending,
+  deleteSuccess,
+  fetchAllError,
+  fetchAllPending,
+  fetchAllSuccess,
+  fetchOneError,
+  fetchOnePending,
+  fetchOneSuccess,
+  updateError,
+  updatePending,
+  updateSuccess,
+} from "./actions";
+
+const ENDPOINT = "/api/services/app/Template";
+
+interface AbpResult<T> {
+  result: T;
+}
+
+interface AbpPagedResult<T> {
+  items: T[];
+  totalCount: number;
+}
+
+export const TemplateProvider = ({ children }: { children: ReactNode }) => {
+  const instance = getAxiosInstance();
+  const [state, dispatch] = useReducer(TemplateReducer, INITIAL_STATE);
+
+  const fetchAll = useCallback(async () => {
+    dispatch(fetchAllPending());
+    try {
+      const res = await instance.get<AbpResult<AbpPagedResult<ITemplateItem>>>(
+        `${ENDPOINT}/GetAll`,
+      );
+      const { items, totalCount } = res.data.result;
+      dispatch(fetchAllSuccess({ items, totalCount }));
+    } catch {
+      dispatch(fetchAllError());
+    }
+  }, [instance]);
+
+  const fetchById = useCallback(
+    async (id: number) => {
+      dispatch(fetchOnePending());
+      try {
+        const res = await instance.get<AbpResult<ITemplateItem>>(`${ENDPOINT}/Get`, {
+          params: { id },
+        });
+        dispatch(fetchOneSuccess(res.data.result));
+      } catch {
+        dispatch(fetchOneError());
+      }
+    },
+    [instance],
+  );
+
+  const create = useCallback(
+    async (data: ITemplateCreateInput) => {
+      dispatch(createPending());
+      try {
+        await instance.post(`${ENDPOINT}/Create`, data);
+        dispatch(createSuccess());
+        await fetchAll();
+      } catch (error) {
+        dispatch(createError());
+        throw error;
+      }
+    },
+    [fetchAll, instance],
+  );
+
+  const update = useCallback(
+    async (data: ITemplateUpdateInput) => {
+      dispatch(updatePending());
+      try {
+        await instance.put(`${ENDPOINT}/Update`, data);
+        dispatch(updateSuccess());
+        await fetchAll();
+      } catch (error) {
+        dispatch(updateError());
+        throw error;
+      }
+    },
+    [fetchAll, instance],
+  );
+
+  const remove = useCallback(
+    async (id: number) => {
+      dispatch(deletePending());
+      try {
+        await instance.delete(`${ENDPOINT}/Delete`, { params: { id } });
+        dispatch(deleteSuccess());
+        await fetchAll();
+      } catch (error) {
+        dispatch(deleteError());
+        throw error;
+      }
+    },
+    [fetchAll, instance],
+  );
+
+  return (
+    <TemplateStateContext.Provider value={state}>
+      <TemplateActionContext.Provider
+        value={{ fetchAll, fetchById, create, update, remove }}
+      >
+        {children}
+      </TemplateActionContext.Provider>
+    </TemplateStateContext.Provider>
+  );
+};
+
+export const useTemplateState = () => {
+  const context = useContext(TemplateStateContext);
+  if (!context) {
+    throw new Error("useTemplateState must be used within TemplateProvider");
+  }
+  return context;
+};
+
+export const useTemplateAction = () => {
+  const context = useContext(TemplateActionContext);
+  if (!context) {
+    throw new Error("useTemplateAction must be used within TemplateProvider");
+  }
+  return context;
+};
+
+export type { ITemplateCreateInput, ITemplateItem, ITemplateUpdateInput } from "./context";

--- a/frontend/src/providers/templates-provider/reducer.test.ts
+++ b/frontend/src/providers/templates-provider/reducer.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { TemplateReducer } from "./reducer";
+import { INITIAL_STATE } from "./context";
+import { fetchAllPending, fetchAllSuccess, fetchAllError } from "./actions";
+
+describe("TemplateReducer", () => {
+  it("sets pending state on fetch all pending", () => {
+    const next = TemplateReducer(INITIAL_STATE, fetchAllPending());
+
+    expect(next.isPending).toBe(true);
+    expect(next.isSuccess).toBe(false);
+    expect(next.isError).toBe(false);
+  });
+
+  it("stores templates on fetch all success", () => {
+    const next = TemplateReducer(
+      INITIAL_STATE,
+      fetchAllSuccess({
+        items: [
+          {
+            id: 1,
+            name: "Landing Page",
+            slug: "landing-page",
+            category: "Marketing",
+          },
+        ],
+        totalCount: 1,
+      }),
+    );
+
+    expect(next.isPending).toBe(false);
+    expect(next.isSuccess).toBe(true);
+    expect(next.items).toHaveLength(1);
+    expect(next.totalCount).toBe(1);
+  });
+
+  it("sets error state on fetch all error", () => {
+    const next = TemplateReducer(INITIAL_STATE, fetchAllError());
+
+    expect(next.isPending).toBe(false);
+    expect(next.isSuccess).toBe(false);
+    expect(next.isError).toBe(true);
+  });
+});

--- a/frontend/src/providers/templates-provider/reducer.tsx
+++ b/frontend/src/providers/templates-provider/reducer.tsx
@@ -1,0 +1,72 @@
+import { handleActions } from "redux-actions";
+import { INITIAL_STATE, ITemplateStateContext } from "./context";
+import { TemplateStateEnums } from "./actions";
+
+export const TemplateReducer = handleActions<
+  ITemplateStateContext,
+  Partial<ITemplateStateContext>
+>(
+  {
+    [TemplateStateEnums.TEMPLATE_FETCH_ALL_PENDING]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_FETCH_ALL_SUCCESS]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_FETCH_ALL_ERROR]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_FETCH_ONE_PENDING]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_FETCH_ONE_SUCCESS]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_FETCH_ONE_ERROR]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_CREATE_PENDING]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_CREATE_SUCCESS]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_CREATE_ERROR]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_UPDATE_PENDING]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_UPDATE_SUCCESS]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_UPDATE_ERROR]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_DELETE_PENDING]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_DELETE_SUCCESS]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+    [TemplateStateEnums.TEMPLATE_DELETE_ERROR]: (state, { payload }) => ({
+      ...state,
+      ...payload,
+    }),
+  },
+  INITIAL_STATE,
+);


### PR DESCRIPTION
This pull request introduces a new "Templates" feature to the frontend application, including a fully functional templates page, state management, provider integration, and corresponding tests. It also updates the sidebar navigation and styles to support this new feature.

**Key changes include:**

**Templates Feature Implementation:**

- Added a new `TemplatesPage` component (`page.tsx`) that displays a searchable and filterable list of backend templates, with support for category filtering, search, and various UI states (loading, error, empty, and populated). The page uses Ant Design components and custom styles.
- Created a dedicated style module for the templates page with consistent layout, grid, and card styling using `antd-style`.

**Templates State Management:**

- Introduced a new `TemplateProvider` with context, actions, and reducer logic to manage template data, including fetching, creating, updating, and deleting templates. This includes the context definition, action types, and reducer logic. [[1]](diffhunk://#diff-69fd792d596ea041c33bfaf75bd3f0046f1670718d7e920feed438133d4df021R1-R71) [[2]](diffhunk://#diff-2b406464f632bb7c04ab29ef3ff86b3acdcacf401f4f6fb7e81255cc84b5c35eR1-R114)
- Integrated the `TemplateProvider` into the global application providers, ensuring templates state is available throughout the app. [[1]](diffhunk://#diff-3333b881e11214d5cadf58c75f7b444a0ff6c190857d807b77680f6655906329R5) [[2]](diffhunk://#diff-3333b881e11214d5cadf58c75f7b444a0ff6c190857d807b77680f6655906329L13-R16)

**Sidebar and Navigation:**

- Added a "Templates" entry with an appropriate icon to the sidebar navigation, enabling users to access the new templates page. [[1]](diffhunk://#diff-56ee873d8e97d3fb31498cf07e1ebf82c88ddd1a3eca51959f15ff2c227874fcR6) [[2]](diffhunk://#diff-56ee873d8e97d3fb31498cf07e1ebf82c88ddd1a3eca51959f15ff2c227874fcR43-R47)
- Minor code cleanup for sidebar navigation logic.

**Testing:**

- Added comprehensive tests for the `TemplatesPage` component, covering loading, filtering, and error states.
- Added provider-level tests for template actions, including fetch, create, and error handling, using mocked axios requests.